### PR TITLE
Refactor: Use environment variables for Radarr config

### DIFF
--- a/example.env
+++ b/example.env
@@ -3,3 +3,5 @@ RADARR_API_KEY=<key>
 BOT_TOKEN=<key>
 TELEGRAM_USER=<User ID>
 RADARR_URL=<URL>
+RADARR_QUALITY_PROFILE_ID=<your_quality_profile_id>
+RADARR_ROOT_FOLDER_PATH=<your_radarr_root_folder_path>

--- a/radarr.py
+++ b/radarr.py
@@ -211,12 +211,11 @@ async def add_movie_to_radarr(movie_details: dict) -> bool:
     }
     payload = {
         "title": movie_details['title'],
-        #"qualityProfileId": 1,  # Adjust based on your Radarr settings
         "titleSlug": movie_details['title'].lower().replace(' ', '-'),
         "tmdbId": movie_details['id'],
         "year": movie_details['release_date'][:4],
-        "rootFolderPath": "/external-media/movies",  # Adjust based on your Radarr settings
-        "qualityProfileId": 4,
+        "rootFolderPath": os.getenv("RADARR_ROOT_FOLDER_PATH", "/external-media/movies"),
+        "qualityProfileId": int(os.getenv("RADARR_QUALITY_PROFILE_ID", 4)),
         "monitored": True,
         "addOptions": {"searchForMovie": True}
     }


### PR DESCRIPTION
This change modifies the Radarr integration to read `qualityProfileId` and `rootFolderPath` from environment variables (`RADARR_QUALITY_PROFILE_ID` and `RADARR_ROOT_FOLDER_PATH` respectively).

Default values are provided if these environment variables are not set, ensuring backward compatibility:
- `qualityProfileId` defaults to `4`.
- `rootFolderPath` defaults to `"/external-media/movies"`.

The `example.env` file has been updated to include these new variables as guidance for you.